### PR TITLE
fix: mark 'Items' property as required in Resource List Class

### DIFF
--- a/src/KubernetesCRDModelGen.Base/OpenApiSchemaModelBuilder.cs
+++ b/src/KubernetesCRDModelGen.Base/OpenApiSchemaModelBuilder.cs
@@ -100,7 +100,7 @@ internal sealed class OpenApiSchemaModelBuilder
                     new GeneratedPropertyModel("ApiVersion", "apiVersion", StringType, "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources", false, group + "/" + version),
                     new GeneratedPropertyModel("Kind", "kind", StringType, "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds", false, listKind),
                     new GeneratedPropertyModel("Metadata", "metadata", V1ListMetaType, "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}."),
-                    new GeneratedPropertyModel("Items", "items", Generic("IList", Named(classNameValue)), $"List of {classNameValue} objects.", isRequired: true)
+                    new GeneratedPropertyModel("Items", "items", Generic("IList", Named(classNameValue)), $"List of {classNameValue} objects.", isNullable: false, isRequired: true)
                 ],
                 isObsolete,
                 obsoleteMessage));

--- a/src/KubernetesCRDModelGen.Base/OpenApiSchemaModelBuilder.cs
+++ b/src/KubernetesCRDModelGen.Base/OpenApiSchemaModelBuilder.cs
@@ -100,7 +100,7 @@ internal sealed class OpenApiSchemaModelBuilder
                     new GeneratedPropertyModel("ApiVersion", "apiVersion", StringType, "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources", false, group + "/" + version),
                     new GeneratedPropertyModel("Kind", "kind", StringType, "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds", false, listKind),
                     new GeneratedPropertyModel("Metadata", "metadata", V1ListMetaType, "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}."),
-                    new GeneratedPropertyModel("Items", "items", Generic("IList", Named(classNameValue)), $"List of {classNameValue} objects.")
+                    new GeneratedPropertyModel("Items", "items", Generic("IList", Named(classNameValue)), $"List of {classNameValue} objects.", isRequired: true)
                 ],
                 isObsolete,
                 obsoleteMessage));

--- a/tests/KubernetesCRDModelGen.Tests/OpenApiSchemaModelBuilderTests.cs
+++ b/tests/KubernetesCRDModelGen.Tests/OpenApiSchemaModelBuilderTests.cs
@@ -156,6 +156,7 @@ properties:
         list.IsKubernetesEntity.ShouldBeTrue();
         list.BaseTypes.Select(x => x.DisplayName).ShouldBe(["IKubernetesObject<V1ListMeta>", "IItems<V1Widget>"]);
         list.Properties.Select(x => x.Name).ShouldBe(["ApiVersion", "Kind", "Metadata", "Items"]);
+        list.Properties.Single(x => x.Name == "Items").IsRequired.ShouldBeTrue();
         list.Properties.Single(x => x.Name == "ApiVersion").InitializerValue.ShouldBe("example.com/v1");
         list.Properties.Single(x => x.Name == "Kind").InitializerValue.ShouldBe("WidgetList");
 

--- a/tests/KubernetesCRDModelGen.Tests/OpenApiSchemaModelBuilderTests.cs
+++ b/tests/KubernetesCRDModelGen.Tests/OpenApiSchemaModelBuilderTests.cs
@@ -157,6 +157,7 @@ properties:
         list.BaseTypes.Select(x => x.DisplayName).ShouldBe(["IKubernetesObject<V1ListMeta>", "IItems<V1Widget>"]);
         list.Properties.Select(x => x.Name).ShouldBe(["ApiVersion", "Kind", "Metadata", "Items"]);
         list.Properties.Single(x => x.Name == "Items").IsRequired.ShouldBeTrue();
+        list.Properties.Single(x => x.Name == "Items").IsNullable.ShouldBeFalse();
         list.Properties.Single(x => x.Name == "ApiVersion").InitializerValue.ShouldBe("example.com/v1");
         list.Properties.Single(x => x.Name == "Kind").InitializerValue.ShouldBe("WidgetList");
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes list model generation so list contents are treated as required and non-nullable, yielding more accurate validation for generated schemas.
* **Tests**
  * Added/updated tests to verify the required/non-nullable behavior for list items in generated Kubernetes models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->