### PR TITLE
feat(SyncTool): Add OCI Helm support

### DIFF
--- a/src/KubernetesCRDModelGen.Sync/HelmClient.cs
+++ b/src/KubernetesCRDModelGen.Sync/HelmClient.cs
@@ -6,40 +6,25 @@ namespace KubernetesCRDModelGen.Sync;
 
 public static class HelmClient
 {
-    public static async Task RepoAdd(string name, string url)
-    {
-        await Cli.Wrap("helm")
-            .WithArguments(new[] { "repo", "add", name, url })
-            .WithStandardOutputPipe(PipeTarget.ToDelegate(Console.WriteLine))
-            .WithStandardErrorPipe(PipeTarget.ToDelegate(Console.WriteLine))
-            .ExecuteBufferedAsync();
-    }
-
-    public static async Task RepoRemove(string name)
-    {
-        await Cli.Wrap("helm")
-            .WithArguments(new[] { "repo", "remove", name })
-            .WithValidation(CommandResultValidation.None)
-            .WithStandardOutputPipe(PipeTarget.ToDelegate(Console.WriteLine))
-            .WithStandardErrorPipe(PipeTarget.ToDelegate(Console.WriteLine))
-            .ExecuteBufferedAsync();
-    }
-
-    public static async Task RepoUpdate()
-    {
-        await Cli.Wrap("helm")
-            .WithArguments(new[] { "repo", "update" })
-            .WithStandardOutputPipe(PipeTarget.ToDelegate(Console.WriteLine))
-            .WithStandardErrorPipe(PipeTarget.ToDelegate(Console.WriteLine))
-            .ExecuteBufferedAsync();
-    }
-
-    public static async Task<string> Template(string repo, string name, bool devel, string appendCMD)
+    public static async Task<string> TemplateHttpRepo(string repo, string name, bool devel, string appendCMD)
     {
         var stdOutBuffer = new StringBuilder();
 
         await Cli.Wrap("helm")
-            .WithArguments($"template {repo}/{name} --include-crds{(devel ? " --devel" : "")} {appendCMD}")
+            .WithArguments($"template {name} --repo {repo} --include-crds{(devel ? " --devel" : "")} {appendCMD}")
+            .WithStandardOutputPipe(PipeTarget.ToStringBuilder(stdOutBuffer))
+            .WithStandardErrorPipe(PipeTarget.ToDelegate(Console.WriteLine))
+            .ExecuteBufferedAsync();
+
+        return stdOutBuffer.ToString();
+    }
+
+    public static async Task<string> TemplateOCIRepo(string repo, string name, bool devel, string appendCMD)
+    {
+        var stdOutBuffer = new StringBuilder();
+
+        await Cli.Wrap("helm")
+            .WithArguments($"template {name} {repo} --include-crds{(devel ? " --devel" : "")} {appendCMD}")
             .WithStandardOutputPipe(PipeTarget.ToStringBuilder(stdOutBuffer))
             .WithStandardErrorPipe(PipeTarget.ToDelegate(Console.WriteLine))
             .ExecuteBufferedAsync();

--- a/src/KubernetesCRDModelGen.Sync/Worker.cs
+++ b/src/KubernetesCRDModelGen.Sync/Worker.cs
@@ -196,18 +196,21 @@ public class Worker : BackgroundService
 
     private async Task ProcessHelmChart(Config config)
     {
-        await HelmClient.RepoRemove("temp");
-        await HelmClient.RepoAdd("temp", config.Helm!.Repo);
-        await HelmClient.RepoUpdate();
+        var yaml = "";
 
-        var yaml = await HelmClient.Template("temp", config.Helm.Chart, config.Helm.PreRelease.GetValueOrDefault(), config.Helm.CMD);
+        if (config.Helm.Repo.StartsWith("oci://"))
+        {
+            yaml = await HelmClient.TemplateOCIRepo(config.Helm.Repo, config.Helm.Chart, config.Helm.PreRelease.GetValueOrDefault(), config.Helm.CMD);
+        }
+        else
+        {
+            yaml = await HelmClient.TemplateHttpRepo(config.Helm.Repo, config.Helm.Chart, config.Helm.PreRelease.GetValueOrDefault(), config.Helm.CMD);
+        }
 
         byte[] byteArray = Encoding.UTF8.GetBytes(yaml);
         var stream = new MemoryStream(byteArray);
 
         ProcessYamlStream(stream);
-
-        await HelmClient.RepoRemove("temp");
     }
 
     private void ProcessYamlStream(Stream stream)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified Helm chart templating workflow by removing repository management operations and introducing repository-type-aware template methods that automatically handle HTTP and OCI repositories differently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->