### PR TITLE
chore: pin conventional-changelog-conventionalcommits to v9

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -32,7 +32,7 @@ jobs:
         dry_run: true
         extra_plugins: |
           @semantic-release/changelog
-          conventional-changelog-conventionalcommits
+          conventional-changelog-conventionalcommits@9
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -76,7 +76,7 @@ jobs:
       with:
         extra_plugins: |
           @semantic-release/changelog
-          conventional-changelog-conventionalcommits
+          conventional-changelog-conventionalcommits@9
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated release process to use a fixed changelog configuration version.
  * No changes to application functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->